### PR TITLE
Fixed MatchError exception in stage 103

### DIFF
--- a/src/main/scala/cz/cvut/fit/palicand/vocloud/ssl/ml/classification/LabelSpreadingClassifier.scala
+++ b/src/main/scala/cz/cvut/fit/palicand/vocloud/ssl/ml/classification/LabelSpreadingClassifier.scala
@@ -58,14 +58,13 @@ final class LabelSpreadingClassifier(override val uid: String) extends GraphClas
     val laplacian = new CoordinateMatrix(degrees.cartesian(degrees).filter { case ((i, (v1, d1)), (j, (v2, d2))) =>
       (i, j) match {
         case (`j`, _) if v1.numNonzeros > 1 => true
-        //case (`i`, `j`) if v1(j.toInt) != 0 && v2(i.toInt) != 0 => true //hotfix by kozajaku
         case (`i`, `j`) if (v1(j.toInt) !== 0.0 +- 0.0000001) && (v2(i.toInt) !== 0.0 +- 0.0000001) => true
         case _ => false
       }
     }.map {case ((i, (v1, d1)), (j, (v2, d2))) =>
       new MatrixEntry(i, j, (i, j) match {
         case (`j`, _) if v1.numNonzeros > 1 => $(alpha)
-        case (`i`, `j`) /*if (v1(j.toInt) !== 0.0 +- 0.0000001) && (v2(i.toInt) !== 0.0 +- 0.0000001) // not necessary */ => $(alpha) / math.sqrt(d1 * d2)
+        case (`i`, `j`) => $(alpha) / math.sqrt(d1 * d2)
       })
     }, distances.numRows,
               distances.numCols).toBlockMatrix(toLabel.rowsPerBlock, toLabel.colsPerBlock).cache()

--- a/src/main/scala/cz/cvut/fit/palicand/vocloud/ssl/ml/classification/LabelSpreadingClassifier.scala
+++ b/src/main/scala/cz/cvut/fit/palicand/vocloud/ssl/ml/classification/LabelSpreadingClassifier.scala
@@ -58,13 +58,14 @@ final class LabelSpreadingClassifier(override val uid: String) extends GraphClas
     val laplacian = new CoordinateMatrix(degrees.cartesian(degrees).filter { case ((i, (v1, d1)), (j, (v2, d2))) =>
       (i, j) match {
         case (`j`, _) if v1.numNonzeros > 1 => true
-        case (`i`, `j`) if v1(j.toInt) != 0 && v2(i.toInt) != 0 => true
+        //case (`i`, `j`) if v1(j.toInt) != 0 && v2(i.toInt) != 0 => true //hotfix by kozajaku
+        case (`i`, `j`) if (v1(j.toInt) !== 0.0 +- 0.0000001) && (v2(i.toInt) !== 0.0 +- 0.0000001) => true
         case _ => false
       }
     }.map {case ((i, (v1, d1)), (j, (v2, d2))) =>
       new MatrixEntry(i, j, (i, j) match {
         case (`j`, _) if v1.numNonzeros > 1 => $(alpha)
-        case (`i`, `j`) if (v1(j.toInt) !== 0.0 +- 0.0000001) && (v2(i.toInt) !== 0.0 +- 0.0000001) => $(alpha) / math.sqrt(d1 * d2)
+        case (`i`, `j`) /*if (v1(j.toInt) !== 0.0 +- 0.0000001) && (v2(i.toInt) !== 0.0 +- 0.0000001) // not necessary */ => $(alpha) / math.sqrt(d1 * d2)
       })
     }, distances.numRows,
               distances.numCols).toBlockMatrix(toLabel.rowsPerBlock, toLabel.colsPerBlock).cache()


### PR DESCRIPTION
Fixed match clause in LabelSpreadingClassifier to properly filter all items before mapping them with a match guard pattern. This bug ended execution during the execution stage 103 for some data. Tested on both Metacentrum and Betelgeuse+Antares Hadoop clusters.
